### PR TITLE
Intel IRIS workaround

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 5.1.18
+
+- disabled multisampling for text outline - fix for https://github.com/aardvark-platform/aardvark.rendering/issues/86
+
 ### 5.1.17
 - fixed package dependeny to FSharp.Data.Adaptive
 - [Vulkan] fixed package dependency to GLSLangSharp

--- a/src/Aardvark.Rendering.Text/SceneGraph.fs
+++ b/src/Aardvark.Rendering.Text/SceneGraph.fs
@@ -227,7 +227,14 @@ module Sg =
             let pass = scope.RenderPass
             let pass = if pass = RenderPass.main then RenderPass.shapes else pass
 
-            shapes.RasterizerState.Multisample <- AVal.map2 (fun a f -> not f || a) aa fill
+            
+            let multisample = 
+                (aa, fill) ||> AVal.map2 (fun a f -> 
+                    // @krauthaufen - why always multisampling when outline only?
+                    not f || a
+                )
+
+            shapes.RasterizerState.Multisample <- multisample
             shapes.RenderPass <- if pass = RenderPass.main then RenderPass.shapes else pass
             shapes.BlendState.Mode <- AVal.constant BlendMode.Blend
             shapes.VertexAttributes <- cache.VertexBuffers
@@ -364,7 +371,15 @@ module Sg =
 
             let pass = scope.RenderPass
             let pass = if pass = RenderPass.main then RenderPass.shapes else pass
-            shapes.RasterizerState.Multisample <- AVal.map2 (fun a f -> not f || a) aa fill
+
+            
+            let multisample = 
+                (aa, fill) ||> AVal.map2 (fun a f -> 
+                    // @krauthaufen - why always multisampling when outline only?
+                    not f || a
+                )
+
+            shapes.RasterizerState.Multisample <- multisample
             shapes.RenderPass <- pass
             shapes.BlendState.Mode <- AVal.constant BlendMode.Blend
             shapes.VertexAttributes <- cache.VertexBuffers
@@ -376,6 +391,7 @@ module Sg =
             //shapes.WriteBuffers <- Some (Set.ofList [DefaultSemantic.Colors])
 
             let boundary = RenderObject.ofScope scope
+            boundary.RasterizerState.Multisample <- multisample
             boundary.RenderPass <- pass
             boundary.BlendState.Mode <- AVal.constant BlendMode.Blend
             boundary.VertexAttributes <- cache.VertexBuffers

--- a/src/Application/Aardvark.Application.Slim/Window.fs
+++ b/src/Application/Aardvark.Application.Slim/Window.fs
@@ -199,24 +199,25 @@ module private GameWindowIO =
 
         let mousePos() =
             try
-             match ctrl with
-                | Some ctrl -> 
-                    let state = OpenTK.Input.Mouse.GetCursorState()
-                    let p = ctrl.PointToClient(Drawing.Point(state.X, state.Y))
-                    let s = ctrl.ClientSize
+                match ctrl with
+                    | Some ctrl -> 
+                        let state = OpenTK.Input.Mouse.GetCursorState()
+                        let p = ctrl.PointToClient(Drawing.Point(state.X, state.Y))
+                        let s = ctrl.ClientSize
         
-                    let x = clamp 0 (s.Width-1) p.X
-                    let y = clamp 0 (s.Height-1) p.Y
+                        let x = clamp 0 (s.Width-1) p.X
+                        let y = clamp 0 (s.Height-1) p.Y
 
-                    PixelPosition(x, y, ctrl.ClientSize.Width, ctrl.ClientSize.Height)
-                | _ ->
-                    PixelPosition(0,0,0,0)
-             with e -> 
+                        PixelPosition(x, y, ctrl.ClientSize.Width, ctrl.ClientSize.Height)
+                    | _ ->
+                        PixelPosition(0,0,0,0)
+            with e -> 
                 Log.warn "could not grab mouse position."
                 lastPos
 
 
-        let onMouseDownHandler = EventHandler<MouseButtonEventArgs>(fun s e -> this.Down(%%e, %e.Button))
+
+        let onMouseDownHandler = EventHandler<MouseButtonEventArgs>(fun s e -> this.Down((%%e), (%e.Button)))
         let onMouseUpHandler = EventHandler<MouseButtonEventArgs>(fun s e -> this.Up(%%e, %e.Button))
         let onMouseMoveHandler = EventHandler<MouseMoveEventArgs>(fun s e -> this.Move %%e)
         let onMouseWheelHandler = EventHandler<MouseWheelEventArgs>(fun s e -> this.Scroll (%%e, (float e.Delta * 120.0)))


### PR DESCRIPTION
- outline now also sets multisampling
- this allows to at least workaround https://github.com/aardvark-platform/aardvark.rendering/issues/86 by setting "Antialias" uniform to false
- it is yet unclear, if we should disable multisample at all if antialias uniform is false- also when using outlines only. please see the comment @krauthaufen 